### PR TITLE
Adapt and revert database configuration changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ media/*
 static-collected/*
 mail_local/*
 _ignoreme_*
+psql/
+mariadb/
+redis/

--- a/compose.ether.yml
+++ b/compose.ether.yml
@@ -29,8 +29,8 @@ services:
     image: ptman/etherpad
     ports:
       - "8002:9001"
-    volumes:
-      - ./settings.json:/opt/etherpad/settings.json
+#    volumes:
+#      - ./settings.json:/opt/etherpad/settings.json
     depends_on:
       - mariadb
   mariadb:

--- a/compose.ether.yml
+++ b/compose.ether.yml
@@ -36,10 +36,10 @@ services:
   mariadb:
     image: mariadb
     environment:
-      MYSQL_RANDOM_ROOT_PASSWORD: yes
-      MYSQL_DATABASE: etherpad
-      MYSQL_USER: etherpad
-      MYSQL_PASSWORD: etherpad
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_DATABASE: "etherpad"
+      MYSQL_USER: "etherpad"
+      MYSQL_PASSWORD: "etherpad"
     volumes:
       - ./mariadb:/var/lib/mysql
  

--- a/devops/settings_docker.py
+++ b/devops/settings_docker.py
@@ -9,7 +9,18 @@ import dj_database_url
 # change this in production!
 ALLOWED_HOSTS = ['*']
 
-DATABASES['default'] = dj_database_url.config('postgres://postgres@db/postgres', conn_max_age=600)
+DATABASES['default'] = dj_database_url.config(conn_max_age=600)
+if not DATABASES['default']:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'postgres',
+            'USER': 'postgres',
+            #'PASSWORD': '',
+            'HOST': 'db',
+            'PORT': '',
+        }
+    }
 
 ADMINS = (
 )


### PR DESCRIPTION
This commit restores working `DATABASE_URL` handling in `settings_docker.py`, plus makes the database configuration for Etherpad work.