### PR TITLE
.gitmodules: Allow cloning of cosinnus-cloud without SSH access

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,4 +33,4 @@
 	url = https://github.com/wechange-eg/cosinnus-todo.git
 [submodule "cosinnus-cloud"]
 	path = cosinnus-cloud
-	url = git@github.com:wechange-eg/cosinnus-cloud.git
+	url = https://github.com/wechange-eg/cosinnus-cloud.git


### PR DESCRIPTION
Hi!

Regular users do not have SSH access so I fixed the clone URL to use HTTPS :smiley: 

Best, Sebastian
