### PR TITLE
Fix the build + make sure that future breakage does not go unnoticed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Copyright (C) 2021 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GNU Affero GPL v3 or later
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+# Copyright (C) 2021 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GNU Affero GPL v3 or later
+
+name: Build with docker-compose
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 4 * * *'  # Every day at 4am
+
+jobs:
+  build_and_test:
+    name: Build with docker-compose
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          submodules: True
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2.2.1
+        with:
+          python-version: 3.9
+
+      - name: Install build dependencies
+        run: |-
+          pip install \
+            --disable-pip-version-check \
+            --user \
+            --no-warn-script-location \
+            docker-compose
+          echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
+
+      - name: Build Docker image
+        run: |-
+          docker-compose build

--- a/.gitmodules
+++ b/.gitmodules
@@ -33,4 +33,4 @@
 	url = https://github.com/wechange-eg/cosinnus-todo.git
 [submodule "cosinnus-cloud"]
 	path = cosinnus-cloud
-	url = git@github.com:wechange-eg/cosinnus-cloud.git
+	url = https://github.com/wechange-eg/cosinnus-cloud.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ WORKDIR /code
 ADD . /code/
 COPY ./docker-entrypoint.sh /
 COPY devops/settings_docker.py /code/devops/settings.py
-RUN pip install -r /code/requirements_docker.txt
+RUN pip install --ignore-installed --disable-pip-version-check pip setuptools wheel \
+        && \
+    hash pip \
+        && \
+    pip install -r /code/requirements_docker.txt
 
 RUN /code/local_setup.sh
 WORKDIR /code/cosinnus-core


### PR DESCRIPTION
Hi!

This pull request:
- (Sits on top of #47 (for an actual chance on a green build) but I'm happy to rebase it off of it in case #47 gets merged first.)
- Fixes the build
- Adds essential CI so we'll notice if the build ever breaks again (see https://github.com/hartwork/cosinnus-devops/actions for the current build log)
- Configures GitHub Dependabot to keep the added GitHub Action up to date

What do you think?

Best, Sebastian